### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,14 +16,14 @@ ByteOutputStream	KEYWORD1
 
 read	KEYWORD2
 peek	KEYWORD2
-seek KEYWORK2
+seek	KEYWORK2
 available	KEYWORD2
 write	KEYWORD2
 flush	KEYWORD2
-hasReadBuffer KEYWORD2
-hasReadStream KEYWORD2
-getReadBuffer KEYWORD2
-getReadStream KEYWORD2
+hasReadBuffer	KEYWORD2
+hasReadStream	KEYWORD2
+getReadBuffer	KEYWORD2
+getReadStream	KEYWORD2
 setReadSource	KEYWORD2
 resetReadSource	KEYWORD2
 read	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords